### PR TITLE
fix(seo): derive canonical URL from current path

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
 	import SignInOut from '$lib/components/SignInOut.svelte';
 	import car from '$lib/images/car.svg';
 
@@ -10,6 +11,8 @@
 	}
 
 	const { children, data }: Props = $props();
+
+	const canonical = $derived(`https://www.whichrouteisfaster.com${page.url.pathname}`);
 
 	$effect(() => {
 		const script = document.createElement('script');
@@ -37,7 +40,7 @@
 	<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 	<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 	<link rel="manifest" href="/site.webmanifest" />
-	<link rel="canonical" href="https://www.whichrouteisfaster.com/" />
+	<link rel="canonical" href={canonical} />
 </svelte:head>
 
 <div class="grid gap-8 py-8 lg:gap-12">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -77,7 +77,6 @@
 		content="Helping you figure out which route is faster, the most boring way possible"
 	/>
 	<meta property="og:url" content="https://www.whichrouteisfaster.com/" />
-	<link rel="canonical" href="https://www.whichrouteisfaster.com/" />
 </svelte:head>
 
 <div>

--- a/src/routes/policies/+page.svelte
+++ b/src/routes/policies/+page.svelte
@@ -1,6 +1,5 @@
 <svelte:head>
 	<title>Policies | Which Route Is Faster</title>
-	<link rel="canonical" href="https://www.whichrouteisfaster.com/" />
 </svelte:head>
 
 <div class="prose lg:prose-xl">


### PR DESCRIPTION
All three canonical tags were hardcoded to the site root, so /policies declared itself a duplicate of the homepage and emitted two canonical tags (one from the layout, one from the page).

Derive the canonical href from page.url.pathname in the layout and drop the duplicate per-page tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated canonical page links to automatically reflect the current page URL.
  * Removed duplicate or outdated canonical links from individual pages.
  * Preserved existing page titles and policy content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->